### PR TITLE
Use Plugin for Vundle docs

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -18,11 +18,11 @@ with is 1.9+ compatible.
 
 Also, you'll need `curl` installed.
 
-If you use Vundle put this in your vimrc:
+If you use [Vundle](https://github.com/gmarik/Vundle.vim) put this in your `vimrc`:
 
 ```
-Bundle 'junkblocker/patchreview-vim'
-Bundle 'codegram/vim-codereview'
+Plugin 'junkblocker/patchreview-vim'
+Plugin 'codegram/vim-codereview'
 ```
 
 If you use Pathogen, clone this repo in your `~/.vim/bundle` directory.


### PR DESCRIPTION
Vundle no longer uses `Bundle` but instead uses `Plugin` since [commit 0521de95](https://github.com/gmarik/Vundle.vim/commit/0521de95eac09298c4e71b3662839612280c1ae9).
