### PR TITLE
Add support for GitHub Enterprise instances

### DIFF
--- a/doc/codereview.txt
+++ b/doc/codereview.txt
@@ -63,4 +63,9 @@ changed file in a new tab.
 The first time, it'll ask you for a GitHub authorization token. You can
 generate those from your Applications settings in your GitHub account page.
 
+					      *g:CODEREVIEW_GITHUB_DOMAIN*
+g:CODEREVIEW_GITHUB_DOMAIN
+	If using codereview against a GitHub Enterprise environment, set this
+	to the domain that the instance is served on.
+
 vim:tw=78:ts=8:ft=help:norl:

--- a/lib/github.rb
+++ b/lib/github.rb
@@ -95,12 +95,18 @@ class Github
   end
 
   def url_info
-    url.scan(/github\.com\/(.*)\/(.*)\/pull\/(\d+)/).first
+    url.scan(/#{Vim.evaluate('g:CODEREVIEW_GITHUB_DOMAIN')}\/(.*)\/(.*)\/pull\/(\d+)/).first
   end
 
   def base_api_url(issue=false)
     user, repo, pull = url_info
-    "https://api.github.com/repos/#{user}/#{repo}/#{issue ? 'issues' : 'pulls'}/#{pull}"
+    api_endpoint = if Vim.evaluate('g:CODEREVIEW_GITHUB_DOMAIN') == 'github.com'
+                     'api.github.com'
+                   else
+                     Vim.evaluate('g:CODEREVIEW_GITHUB_DOMAIN') + '/api/v3'
+                   end
+
+    "https://#{api_endpoint}/repos/#{user}/#{repo}/#{issue ? 'issues' : 'pulls'}/#{pull}"
   end
 
   def curl(args)

--- a/plugin/codereview.vim
+++ b/plugin/codereview.vim
@@ -1,3 +1,6 @@
+if !exists('g:CODEREVIEW_GITHUB_DOMAIN')
+  let g:CODEREVIEW_GITHUB_DOMAIN = 'github.com'
+end
 if !exists('g:CODEREVIEW_INSTALL_PATH')
   let g:CODEREVIEW_INSTALL_PATH = fnamemodify(expand("<sfile>"), ":p:h")
 end


### PR DESCRIPTION
We need to make it possible for the user to specify a different GitHub
endpoint in the case that they're pointing it to a GitHub Enterprise
instance.

Because GitHub Enterprise uses a different domain and URL layout than
GitHub.com, we need a logic to specify the API endpoint.

Retain defaults as `github.com`, but allows overriding in user's
`.vimrc`.

Closes #11.